### PR TITLE
Extract Surface.Catalogue.Server to an .exs file

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ Create a `dev.exs` script at the root of your project with the following content
 
 Logger.configure(level: :debug)
 
+Code.require_file("deps/surface_catalogue/server.exs")
+
 # Start the catalogue server
 Surface.Catalogue.Server.start(
   live_reload: [

--- a/dev.exs
+++ b/dev.exs
@@ -2,6 +2,8 @@
 
 Logger.configure(level: :debug)
 
+Code.require_file("server.exs")
+
 Surface.Catalogue.Server.start(
   watchers: [
     node: [

--- a/mix.exs
+++ b/mix.exs
@@ -49,7 +49,7 @@ defmodule Surface.Catalogue.MixProject do
       {:jason, "~> 1.0"},
       {:html_entities, "~> 0.4"},
       {:plug_cowboy, "~> 2.0"},
-      {:phoenix_live_reload, "~> 1.2"},
+      {:phoenix_live_reload, "~> 1.2", only: :dev},
       {:surface, "~> 0.3.2"},
       {:ex_doc, ">= 0.19.0", only: :docs},
       {:makeup_elixir, "~> 0.15.1"}

--- a/server.exs
+++ b/server.exs
@@ -1,3 +1,7 @@
+# iex -S mix dev
+
+Logger.configure(level: :debug)
+
 defmodule Surface.Catalogue.Server do
   @moduledoc """
   A simple catalogue server that can be used to load catalogues from projects that


### PR DESCRIPTION
Try to fix #7 

I am not sure it is the right way to do but, it works. The only downside I have identified is that someone who would like to use the the built-in catalogue server, he should also add `{:phoenix_live_reload, "~> 1.2", only: :dev}` in his `mix.exs` file.

It tested it with the `surface_bootstrap` package by updating it's `dev.exs` and `mix.exs` files and it seems to work correctly.

@msaraiva if you have a better proposition, I would be glad to tackle this at it's a serious bottleneck to use `surface_catalogue` in real project except libraries.  