### PR TITLE
Enable scroll on Examples

### DIFF
--- a/lib/surface/catalogue/live/page_live.ex
+++ b/lib/surface/catalogue/live/page_live.ex
@@ -133,7 +133,7 @@ defmodule Surface.Catalogue.PageLive do
                     <div :show={{ @action == "example" }} class="Example {{example.direction}}">
                       <div class="demo" style="width: {{example.demo_perc}}%">
                         <iframe
-                          scrolling="no"
+                          scrolling={{ if example.scrolling, do: "yes", else: "no"}}
                           id="example-iframe-{{index}}"
                           src={{ path_to(@socket, ExampleLive, example.module_name, __window_id__: @__window_id__) }}
                           style="overflow-y: hidden; width: 100%; height: {{ example.height }};"

--- a/lib/surface/catalogue/util.ex
+++ b/lib/surface/catalogue/util.ex
@@ -28,6 +28,7 @@ defmodule Surface.Catalogue.Util do
       title = Keyword.get(config, :title)
       direction = Keyword.get(config, :direction) || "horizontal"
       height = Keyword.get(config, :height) || "120px"
+      scrolling = Keyword.get(config, :scrolling) || false
 
       {demo_perc, code_perc} =
         case {direction, Keyword.get(config, :code_perc)} do
@@ -49,7 +50,8 @@ defmodule Surface.Catalogue.Util do
         code: code,
         direction: direction,
         demo_perc: demo_perc,
-        code_perc: code_perc
+        code_perc: code_perc,
+        scrolling: scrolling
       }
     end
     |> Enum.sort_by(& &1.module_name)


### PR DESCRIPTION
I am experimenting with nested components and needed more space to preview examples.

This pull request adds a conditional to the scrolling property on the iframe in "page_live.ex" and makes the setting available in example.ex files. Just add a `scrolling: true` where you set the height and the iframe becomes scrollable. 