### PR TITLE
Update example code when switching from one example to another

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -210,6 +210,9 @@ Hooks["Highlight"] = {
 
     // Call it again to fix misplaced selected lines on page reload
     Prism.highlightElement(this.el)
+  },
+  updated() {
+    Prism.highlightElement(this.el);
   }
 }
 

--- a/lib/surface/catalogue/live/page_live.ex
+++ b/lib/surface/catalogue/live/page_live.ex
@@ -141,7 +141,7 @@ defmodule Surface.Catalogue.PageLive do
                           phx-hook="IframeBody"
                         />
                       </div>
-                      <div class="code" phx-update="ignore" style="width: {{example.code_perc}}%">
+                      <div class="code" style="width: {{example.code_perc}}%">
                         <pre class="language-surface">
                           <code class="content language-surface" phx-hook="Highlight" id="example-code-{{index}}">
     {{ example.code }}</code>


### PR DESCRIPTION
This fixes #13 , but I'm wondering if there was a reason for the `phx-update="ignore"` I am missing. 

In case that is an acceptable change, note that I didn't update the JS file in `priv/`. I was not sure if that is desired or if it's handled like for `phoenix_live_view` where it's updated by the maintainers.