### PR TITLE
sssigns -> assigns

### DIFF
--- a/lib/surface/catalogue/components/playground_tools.ex
+++ b/lib/surface/catalogue/components/playground_tools.ex
@@ -100,7 +100,7 @@ defmodule Surface.Catalogue.Components.PlaygroundTools do
 
             <div class="field is-horizontal">
               <div class="field-label is-small">
-                <label class="label">Playground's sssigns</label>
+                <label class="label">Playground's assigns</label>
               </div>
               <div class="field-body">
                 <div class={:field, "has-text-grey-light": @playground_info.hibernating?}>


### PR DESCRIPTION
This just caught my eye when working on my project at SpawnFest, since it's a tiny change, thought I'd send a PR and add a fix instead of just mentioning it. It was showing `sssigns` instead of `assigns` :) 