### PR TITLE
stop ignoring liveview diffs on code snippet container

### DIFF
--- a/lib/surface/catalogue/live/page_live.ex
+++ b/lib/surface/catalogue/live/page_live.ex
@@ -142,7 +142,7 @@ defmodule Surface.Catalogue.PageLive do
                         />
                       </div>
 
-                      <div class="code" phx-update="ignore" style={"width: #{example.code_perc}%"}>
+                      <div class="code" style={"width: #{example.code_perc}%"}>
                         <pre class="language-surface">
                           <code class="content language-surface" phx-hook="Highlight" id={"example-code-#{index}"}>
     {example.code}</code>


### PR DESCRIPTION
**what is this?**
re-implementing the fix for https://github.com/surface-ui/surface_catalogue/issues/13 - looks like a regression snuck in during a run of `mix surface.convert` in https://github.com/surface-ui/surface_catalogue/pull/15/files#diff-02eaac6d9911de90de16ae0d200d87bff2eb2efe08703a826a9a56faf6da38aeL144-R145

before:

https://user-images.githubusercontent.com/81541018/134599300-99aa3df3-d341-4e43-adbd-a1877820e256.mov

after:

https://user-images.githubusercontent.com/81541018/134599323-e82925e8-9d17-42e9-b9e6-17f5dc3269b7.mov

thanks for all of the awesome effort put towards surface, liveview and surface catalogue! very excited about the tailwindcss direction and the catalogue moving beyond a prototype. please let me know if there's a better place to get involved / look for opportunities to contribute!