### PR TITLE
add arguments column on public API slot section

### DIFF
--- a/lib/surface/catalogue/components/component_api.ex
+++ b/lib/surface/catalogue/components/component_api.ex
@@ -68,7 +68,10 @@ defmodule Surface.Catalogue.Components.ComponentAPI do
               <code>{slot.name}</code>
             </Column>
             <Column label="Description">
-            {format_required(slot)} {slot.doc |> format_desc() |> Markdown.to_html(strip: true)}
+              {format_required(slot)} {slot.doc |> format_desc() |> Markdown.to_html(strip: true)}
+            </Column>
+            <Column label="Arguments">
+              {format_args(slot.opts_ast)}
             </Column>
           </Table>
         </TabItem>
@@ -132,6 +135,22 @@ defmodule Surface.Catalogue.Components.ComponentAPI do
 
   defp format_value(value) do
     inspect(value)
+  end
+
+  defp format_args(opts) when opts in [nil, []] do
+    "—"
+  end
+
+  defp format_args(opts) do
+    if Keyword.has_key?(opts, :args) do
+      opts[:args]
+      |> Enum.map(fn key ->
+        raw(["<code>", inspect(key), "</code>"])
+      end)
+      |> Enum.intersperse(", ")
+    else
+      "—"
+    end
   end
 
   defp format_default(opts) do


### PR DESCRIPTION
- when slots have no arguments should exhibit `--`.
- when slots have one or more arguments should exhibit something like:
  - `:form`
  - `:form`, `:index`

Also, this PR is related to this issue here: https://github.com/surface-ui/surface/issues/583

preview:

<img width="1426" alt="Screen Shot 2022-05-06 at 16 08 27" src="https://user-images.githubusercontent.com/1036970/167202512-b5e00191-b923-42ee-9493-99b15c581f36.png">

---

<img width="1368" alt="Screen Shot 2022-05-06 at 16 08 52" src="https://user-images.githubusercontent.com/1036970/167202522-40fc0e47-5b7f-463d-8f63-518383e61c67.png">

---

<img width="1371" alt="Screen Shot 2022-05-06 at 16 09 27" src="https://user-images.githubusercontent.com/1036970/167202525-04c88ba7-f554-4459-80a0-c9ea13a44338.png">
